### PR TITLE
Fix binary name for mac m1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ GOOS=darwin GOARCH=amd64 go build cmd/gobrew/main.go && mv main bin/gobrew-darwi
 echo "building darwin done"
 
 echo "building darwin arm-64 (m1)"
-GOOS=darwin GOARCH=arm64 go build cmd/gobrew/main.go && mv main bin/gobrew-arm-64
+GOOS=darwin GOARCH=arm64 go build cmd/gobrew/main.go && mv main bin/gobrew-darwin-arm-64
 echo "building darwin arm-64 (m1) done"
 
 echo "building windows 64"


### PR DESCRIPTION
HI @kevincobain2000, thank you for a quick merge of my previous PR. 
Unfortunately, it was too quick and I had a small problem in it. The binary name has a mismatch in the build file and the file to download it. This PR fixes it.

Ref: https://github.com/kevincobain2000/gobrew/pull/21

