### PR TITLE
fixes: Some versions cannot be downloaded and installed, such as 1.17.0, etc

### DIFF
--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/kevincobain2000/gobrew"
 )
@@ -34,6 +35,10 @@ func init() {
 	actionArg = args[0]
 	if len(args) == 2 {
 		versionArg = args[1]
+		versionArgSlice := strings.Split(versionArg, ".")
+		if len(versionArgSlice) == 3 && versionArgSlice[2] == "0" {
+			versionArg = versionArgSlice[0] + "." + versionArgSlice[1]
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes the problem below

$gobrew ls-remote
.......
1.17	1.17.0  1.17.1  1.17.2  1.17.3  1.17.4  1.17.5  1.17.6  1.17.7  1.17.8  1.17beta1  1.17rc1  1.17rc2

$gobrew install 1.17.0
[Info] Downloading version: 1.17.0
[Success] Untar to /Users/xxxxx/.gobrew/versions/1.17.0
[Info]: Untar failed: exit status 1
[Error]: Please check if version exists from url: https://golang.org/dl/go1.17.0.darwin-amd64.tar.gz