### PR TITLE
feat: use version from goreleaser

### DIFF
--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -13,6 +13,7 @@ import (
 var args = []string{}
 var actionArg = ""
 var versionArg = ""
+var version = "dev"
 
 var allowedArgs = []string{"h", "help", "ls", "list", "ls-remote", "install", "use", "uninstall", "self-update"}
 
@@ -101,7 +102,7 @@ func Find(slice []string, val string) (int, bool) {
 
 func usage() string {
 	msg := `
-gobrew 1.6.4
+gobrew ` + version + `
 
 Usage:
 


### PR DESCRIPTION
From [goreleaser/build](https://goreleaser.com/customization/build/):

    # Custom ldflags templates.
    # Default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser`.

By default we have several variables by builds:

- version
- commit
- date
- builtBy

We can use it in main program.

In this time we use only version variable.
For local build without goreleaser version setting to `dev`.

Example build:
https://github.com/juev/gobrew/releases/tag/v1.6.5

Local build with go build:
```bash
~/Pr/Gi/gobrew on  version [?]
 15:07:23  ❯ ./gobrew

gobrew dev
```
