### PR TITLE
1.19 got released?

### DIFF
--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -36,15 +36,13 @@ func TestJudgeVersion(t *testing.T) {
 			version:     "1.18@dev-latest",
 			wantVersion: "1.18.5",
 		},
-		// following 2 tests will fail upon new release of 1.19
-		// at the time of this test, 1.19 is not released yet
 		{
 			version:     "latest",
 			wantVersion: "1.19",
 		},
 		{
 			version:     "dev-latest",
-			wantVersion: "1.19rc2",
+			wantVersion: "1.19",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
```
--- FAIL: TestJudgeVersion (1.03s)
    --- FAIL: TestJudgeVersion/dev-latest (0.12s)
        gobrew_test.go:54: assertion failed: 1.19rc2 (test.wantVersion string) != 1.19 (version string)
```

UT should pass: https://github.com/kevincobain2000/gobrew/pull/41