### PR TITLE
put rc beta in new line

### DIFF
--- a/gobrew.go
+++ b/gobrew.go
@@ -235,6 +235,9 @@ func (gb *GoBrew) getGroupedVersion(versions []string, print bool) map[string][]
 			gb.print(gvSemantic.String()+"  ", print)
 		}
 
+		maxPerLine = 0
+		gb.print("\n\t", true)
+
 		// print rc and beta versions in the end
 		for _, rcVersion := range groupedVersions[lookupKey] {
 			r, _ := regexp.Compile("beta.*|rc.*")


### PR DESCRIPTION
■ Before

```
1.17	1.17.0  1.17.1  1.17.2  1.17.3  1.17.4
	1.17.5  1.17.6  1.17.7  1.17.8  1.17.9  1.17.10
	1.17.11  1.17.12  1.17.13  1.17beta1  1.17rc1  1.17rc2

1.18	1.18.0  1.18.1  1.18.2  1.18.3  1.18.4
	1.18.5  1.18.6  1.18.7  1.18beta1  1.18beta2  1.18rc1

1.19	1.19.0  1.19.1  1.19.2  1.19beta1  1.19rc1  1.19rc2
```

■ After

```
1.17	1.17.0  1.17.1  1.17.2  1.17.3  1.17.4
	1.17.5  1.17.6  1.17.7  1.17.8  1.17.9  1.17.10
	1.17.11  1.17.12  1.17.13
	1.17beta1  1.17rc1  1.17rc2

1.18	1.18.0  1.18.1  1.18.2  1.18.3  1.18.4
	1.18.5  1.18.6  1.18.7
	1.18beta1  1.18beta2  1.18rc1

1.19	1.19.0  1.19.1  1.19.2
	1.19beta1  1.19rc1  1.19rc2
```