### PR TITLE
fixing newline echo statement

### DIFF
--- a/git.io.sh
+++ b/git.io.sh
@@ -43,7 +43,8 @@ case $THISOS in
       ;;
 esac
 
-echo "Installing gobrew...\n"
+echo "Installing gobrew..."
+echo ""
 
 curl -kLs https://github.com/kevincobain2000/gobrew/releases/latest/download/$GOBREW_ARCH_BIN -o $GOBREW_BIN_DIR/gobrew
 


### PR DESCRIPTION
Adding `"...\n"` prints the newline character literally, resulting in `Installing gobrew...\n`, rather than an additional new line.

Adding an empty `echo ""` prints a blank line, which is what I think was intended :)

Either way, thanks for building this!