### PR TITLE
Add windows support for version check and download

### DIFF
--- a/gobrew.go
+++ b/gobrew.go
@@ -310,9 +310,9 @@ func (gb *GoBrew) CurrentVersion() string {
 		return ""
 	}
 
-	version := strings.ReplaceAll(fp, "/go/bin", "")
+	version := strings.ReplaceAll(fp, strings.Join([]string{"go", "bin"}, string(os.PathSeparator)), "")
 	version = strings.ReplaceAll(version, gb.versionsDir, "")
-	version = strings.ReplaceAll(version, "/", "")
+	version = strings.ReplaceAll(version, string(os.PathSeparator), "")
 	return version
 }
 
@@ -528,7 +528,13 @@ func (gb *GoBrew) getVersionDir(version string) string {
 	return filepath.Join(gb.versionsDir, version)
 }
 func (gb *GoBrew) downloadAndExtract(version string) {
-	tarName := "go" + version + "." + gb.getArch() + ".tar.gz"
+	tarName := "go" + version + "." + gb.getArch()
+
+	if runtime.GOOS == "windows" {
+		tarName = tarName + ".zip"
+	} else {
+		tarName = tarName + ".tar.gz"
+	}
 
 	registryPath := defaultRegistryPath
 	if p := os.Getenv("GOBREW_REGISTRY"); p != "" {


### PR DESCRIPTION
This PR fixes the version evaluation and the archive download to make it work on Windows.

It changes CurrentVersion function to use the operating system path separator during the file name cleanup.

It also changes the downloadAndExtract function to download the zip file when the program is running on Windows.