### PR TITLE
Add Windows support for self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ curl -sLk https://git.io/gobrew | sh
 # Limitations
 
 - Windows OS limited support
+  - Because gobrew uses symbolic links it is recomended to enable [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) on Windows.
 
 # Change Log
 

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -30,11 +30,11 @@ func TestJudgeVersion(t *testing.T) {
 		},
 		{
 			version:     "1.18@latest",
-			wantVersion: "1.18.9",
+			wantVersion: "1.18.10",
 		},
 		{
 			version:     "1.18@dev-latest",
-			wantVersion: "1.18.9",
+			wantVersion: "1.18.10",
 		},
 		// // following 2 tests fail upon new version release
 		// // commenting out for now as the tool is stable


### PR DESCRIPTION
This PR fixes the following items:
- `self-update` command when running on Windows.

It also contains some updates:
- Documentation about the symbolic links support on Windows.
- The expected version on `TestJudgeVersion` test.


