### PR TITLE
Use portable code to find user home directory

### DIFF
--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/kevincobain2000/gobrew"
@@ -145,10 +146,23 @@ Examples:
     gobrew use dev-latest          # use go version latest avalable, including rc and beta
 
 Installation Path:
+`
+
+	if runtime.GOOS == "windows" {
+		msg = msg + `
+    # Add gobrew to your environment variables
+    PATH="%USERPROFILE%\.gobrew\current\bin;%USERPROFILE%\.gobrew\bin;%PATH%"
+    GOROOT="%USERPROFILE%\.gobrew\current\go"
+
+`
+	} else {
+		msg = msg + `
     # Add gobrew to your ~/.bashrc or ~/.zshrc
     export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$PATH"
     export GOROOT="$HOME/.gobrew/current/go"
 
 `
+	}
+
 	return msg
 }

--- a/gobrew.go
+++ b/gobrew.go
@@ -71,7 +71,12 @@ var githubTags map[string][]string
 
 // NewGoBrew instance
 func NewGoBrew() GoBrew {
-	gb.homeDir = os.Getenv("HOME")
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		homeDir = os.Getenv("HOME")
+	}
+
+	gb.homeDir = homeDir
 	if os.Getenv("GOBREW_ROOT") != "" {
 		gb.homeDir = os.Getenv("GOBREW_ROOT")
 	}


### PR DESCRIPTION
This make possible to use the tool on Windows without the need of create the HOME environment variable using portable go code.

Method os.UserHomeDir returns the current user's home directory.

* On Unix, including macOS, it returns the $HOME environment variable.
* On Windows, it returns %USERPROFILE%.
* On Plan 9, it returns the $home environment variable.
