### PR TITLE
Fix upgrade on windows and tests

### DIFF
--- a/gobrew.go
+++ b/gobrew.go
@@ -506,7 +506,6 @@ func (gb *GoBrew) Upgrade(currentVersion string) {
 	goBrewFile := filepath.Join(gb.installDir, "bin", "gobrew"+fileExt)
 	if runtime.GOOS == "windows" {
 		goBrewOldFile := goBrewFile + ".old"
-		_ = os.Remove(goBrewOldFile)
 		if err = os.Rename(goBrewFile, goBrewOldFile); err != nil {
 			utils.Errorf("[Error] Cannot rename binary file: %s", err.Error())
 			return

--- a/gobrew.go
+++ b/gobrew.go
@@ -506,9 +506,11 @@ func (gb *GoBrew) Upgrade(currentVersion string) {
 	goBrewFile := filepath.Join(gb.installDir, "bin", "gobrew"+fileExt)
 	if runtime.GOOS == "windows" {
 		goBrewOldFile := goBrewFile + ".old"
-		// do not check for errors as the file will be recreated
 		_ = os.Remove(goBrewOldFile)
-		_ = os.Rename(goBrewFile, goBrewOldFile)
+		if err = os.Rename(goBrewFile, goBrewOldFile); err != nil {
+			utils.Errorf("[Error] Cannot rename binary file: %s", err.Error())
+			return
+		}
 	} else {
 		if err = os.Remove(goBrewFile); err != nil {
 			utils.Errorf("[Error] Cannot remove binary file: %s", err.Error())

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -2,6 +2,7 @@ package gobrew
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -107,26 +108,88 @@ func TestJudgeVersion(t *testing.T) {
 	}
 }
 func TestListVersions(t *testing.T) {
-	gb := NewGoBrew()
-	err := gb.ListVersions()
+	tempDir, err := os.MkdirTemp("", "gobrew-test-list-version-")
+	if err != nil {
+		t.Skip("could not create directory for gobrew update:", err)
+		return
+	}
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	gb := NewGoBrewDirectory(tempDir)
+	err = gb.ListVersions()
 	assert.NilError(t, err)
 }
+
 func TestExistVersion(t *testing.T) {
-	gb := NewGoBrew()
-	exists := gb.existsVersion("1.0") //ideally on tests nothing exists yet
+	tempDir, err := os.MkdirTemp("", "gobrew-test-exists-version-")
+	if err != nil {
+		t.Skip("could not create directory for gobrew update:", err)
+		return
+	}
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	gb := NewGoBrewDirectory(tempDir)
+	exists := gb.existsVersion("1.19")
 	assert.Equal(t, false, exists)
 }
 
 func TestInstallAndExistVersion(t *testing.T) {
-	gb := NewGoBrew()
+	tempDir := filepath.Join(os.TempDir(), "gobrew-test-install-uninstall")
+	err := os.MkdirAll(tempDir, os.ModePerm)
+	if err != nil {
+		t.Skip("could not create directory for gobrew update:", err)
+		return
+	}
+
+	gb := NewGoBrewDirectory(tempDir)
 	gb.Install("1.19")
 	exists := gb.existsVersion("1.19")
 	assert.Equal(t, true, exists)
 }
 
 func TestUnInstallThenNotExistVersion(t *testing.T) {
-	gb := NewGoBrew()
+	tempDir := filepath.Join(os.TempDir(), "gobrew-test-install-uninstall")
+	err := os.MkdirAll(tempDir, os.ModePerm)
+	if err != nil {
+		t.Skip("could not create directory for gobrew update:", err)
+		return
+	}
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	gb := NewGoBrewDirectory(tempDir)
 	gb.Uninstall("1.19")
 	exists := gb.existsVersion("1.19")
 	assert.Equal(t, false, exists)
+}
+
+func TestUpgrade(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "gobrew-test-upgrade-")
+	if err != nil {
+		t.Skip("could not create directory for gobrew update:", err)
+		return
+	}
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	gb := NewGoBrewDirectory(tempDir)
+
+	binaryDir := filepath.Join(gb.installDir, "bin")
+	_ = os.MkdirAll(binaryDir, os.ModePerm)
+	goBrewFile := "gobrew"
+	if runtime.GOOS == "windows" {
+		goBrewFile = goBrewFile + ".exe"
+	}
+
+	gb.Upgrade("0.0.0")
+
+	if _, err := os.Stat(filepath.Join(binaryDir, goBrewFile)); err != nil {
+		t.Errorf("could not find updated executable")
+	}
 }

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -182,14 +182,21 @@ func TestUpgrade(t *testing.T) {
 
 	binaryDir := filepath.Join(gb.installDir, "bin")
 	_ = os.MkdirAll(binaryDir, os.ModePerm)
-	goBrewFile := "gobrew"
+
+	baseName := "gobrew"
 	if runtime.GOOS == "windows" {
-		goBrewFile = goBrewFile + ".exe"
+		baseName = baseName + ".exe"
+	}
+	binaryFile := filepath.Join(binaryDir, baseName)
+
+	if oldFile, err := os.Create(binaryFile); err == nil {
+		// on tests we have to close the file to avoid an error on os.Rename
+		oldFile.Close()
 	}
 
 	gb.Upgrade("0.0.0")
 
-	if _, err := os.Stat(filepath.Join(binaryDir, goBrewFile)); err != nil {
-		t.Errorf("could not find updated executable")
+	if _, err := os.Stat(binaryFile); err != nil {
+		t.Errorf("updated executable does not exist")
 	}
 }


### PR DESCRIPTION
On Windows the executable can not be removed while it is running, but we can rename it and then finish the upgrade.

Also added a new version of the constructor named `NewGoBrewDirectory`.

With this new constructor all tests related to version management and upgrade can run in isolated directories.