### PR TITLE
Sometimes dir exists, which ends up showing that the version that doesn't exist

### DIFF
--- a/gobrew.go
+++ b/gobrew.go
@@ -340,9 +340,6 @@ func (gb *GoBrew) Uninstall(version string) {
 	if gb.CurrentVersion() == version {
 		utils.Fatalf("[Error] Version: %s you are trying to remove is your current version. Please use a different version first before uninstalling the current version\n", version)
 	}
-	if !gb.existsVersion(version) {
-		utils.Fatalf("[Error] Version: %s you are trying to remove is not installed\n", version)
-	}
 	gb.cleanVersionDir(version)
 	utils.Successf("[Success] Version: %s uninstalled\n", version)
 }


### PR DESCRIPTION
    Sometimes dir exists, which ends up showing that the version is installed.
    However version checker checks for real binary instead of the existance of the dir.
    Removing extra condition to fix prune and rm issues.