### PR TITLE
gobrew use mod

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17, 1.18, 1.18@latest, 1.19beta1, 1.19@dev-latest, latest, dev-latest]
+        go-version: [1.17, 1.18, 1.18@latest, 1.19beta1, 1.19@dev-latest, latest, dev-latest, mod]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13, 1.14, 1.15, 1.16.7, 1.17, 1.18, 1.18@latest, 1.19beta1, 1.19@dev-latest, latest, dev-latest]
+        go-version: [1.13, 1.14, 1.15, 1.16.7, 1.17, 1.18, 1.18@latest, 1.19beta1, 1.19@dev-latest, latest, dev-latest, mod]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -260,7 +260,7 @@ jobs:
 
 # Customization
 
-By default, gobrew is installed in `$HOME` as `$HOME/.gobrew`. 
+By default, gobrew is installed in `$HOME` as `$HOME/.gobrew`.
 
 You can change this by setting the `GOBREW_ROOT` environment variable.
 

--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -141,8 +141,8 @@ Examples:
     gobrew use 1.16@dev-latest     # use go version latest of 1.16, including rc and beta
                                    # Note: rc and beta become no longer latest upon major release
 
+    gobrew use mod                 # use go version listed in the go.mod file
     gobrew use latest              # use go version latest available
-
     gobrew use dev-latest          # use go version latest avalable, including rc and beta
 
 Installation Path:


### PR DESCRIPTION
Not exactly fixing #99 but a step in this direction

Usage

```
gobrew use mod // reads version from go.mod file and use the latest version of that
```
