### PR TITLE
Fixes #113 where version 1.21.0 was falling back to 1.21

### DIFF
--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -51,8 +51,7 @@ func init() {
 		versionArg = args[1]
 		versionArgSlice := strings.Split(versionArg, ".")
 		if len(versionArgSlice) == 3 {
-			majorVersionNum, err := strconv.Atoi(versionArgSlice[1])
-			_ = err //ignore, because - reasons
+			majorVersionNum, _ := strconv.Atoi(versionArgSlice[1])
 			// Comply with: https://github.com/kevincobain2000/gobrew/issues/113
 			if versionArgSlice[2] == "0" && majorVersionNum < 21 {
 				// Keep complying with https://github.com/kevincobain2000/gobrew/pull/24

--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/kevincobain2000/gobrew"
@@ -49,8 +50,14 @@ func init() {
 	if len(args) == 2 {
 		versionArg = args[1]
 		versionArgSlice := strings.Split(versionArg, ".")
-		if len(versionArgSlice) == 3 && versionArgSlice[2] == "0" {
-			versionArg = versionArgSlice[0] + "." + versionArgSlice[1]
+		if len(versionArgSlice) == 3 {
+			majorVersionNum, err := strconv.Atoi(versionArgSlice[1])
+			_ = err //ignore, because - reasons
+			// Comply with: https://github.com/kevincobain2000/gobrew/issues/113
+			if versionArgSlice[2] == "0" && majorVersionNum < 21 {
+				// Keep complying with https://github.com/kevincobain2000/gobrew/pull/24
+				versionArg = versionArgSlice[0] + "." + versionArgSlice[1]
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #113 

OK should have no impact

```
╭─pulkit.kathuria@JP-GCJKVGQK0G^M ~/git/gobrew ‹feature/semantic-comply›
╰─$ go run cmd/gobrew/main.go install 1.21rc3
==> [Info] Downloading version: 1.21rc3
==> [Info] Downloading from: https://go.dev/dl/go1.21rc3.darwin-arm64.tar.gz
==> [Info] Downloading to: /Users/pulkit.kathuria/.gobrew/downloads
Downloading   0% |    
```

OK - should fail

```                                                                                                                                                                                                                     | (80 kB/62 MB, 288 kB/s) [0s:3m41s]^Csignal: interrupt
╭─pulkit.kathuria@JP-GCJKVGQK0G^M ~/git/gobrew ‹feature/semantic-comply›
╰─$ go run cmd/gobrew/main.go install 1.21                                                                                                                                                                                                                                  1 ↵
==> [Info] Downloading version: 1.21
==> [Info] Downloading from: https://go.dev/dl/go1.21.darwin-arm64.tar.gz
==> [Info] Downloading to: /Users/pulkit.kathuria/.gobrew/downloads
==> [Info] Downloading version failed: https://go.dev/dl/go1.21.darwin-arm64.tar.gz returned status code 404
==> [Error]: Please check connectivity to url: https://go.dev/dl/go1.21.darwin-arm64.tar.gz
exit status 1
```

OK should pass

```
╭─pulkit.kathuria@JP-GCJKVGQK0G^M ~/git/gobrew ‹feature/semantic-comply›
╰─$                                                                                                                                                                                                                                                                         1 ↵
╭─pulkit.kathuria@JP-GCJKVGQK0G^M ~/git/gobrew ‹feature/semantic-comply›
╰─$ go run cmd/gobrew/main.go install 1.21.0                                                                                                                                                                                                                              130 ↵
==> [Info] Downloading version: 1.21.0
==> [Info] Downloading from: https://go.dev/dl/go1.21.0.darwin-arm64.tar.gz
==> [Info] Downloading to: /Users/pulkit.kathuria/.gobrew/downloads
Downloading   4% |████████                                                                                                                                                                                                                       | (2.8/62 MB, 10 MB/s) [0s:5s]^Csignal: interrupt
```

OK Keep ASIS passing https://github.com/kevincobain2000/gobrew/pull/24
```
╭─pulkit.kathuria@JP-GCJKVGQK0G^M ~/git/gobrew ‹feature/semantic-comply›
╰─$ go run cmd/gobrew/main.go install 1.17.0                                                                                                                                                                                                                                1 ↵
==> [Info] Downloading version: 1.17
==> [Info] Downloading from: https://go.dev/dl/go1.17.darwin-arm64.tar.gz
==> [Info] Downloading to: /Users/pulkit.kathuria/.gobrew/downloads
Downloading   0% |                                                                                                                                                                                                                            | (1.1/123 MB, 6.3 MB/s) [0s:19s]^Csignal: interrupt
╭─pulkit.kathuria@JP-GCJKVGQK0G^M ~/git/gobrew ‹feature/semantic-comply›
╰─$ go run cmd/gobrew/main.go install 1.17                                                                                                                                                                                                                                  1 ↵
==> [Info] Downloading version: 1.17
==> [Info] Downloading from: https://go.dev/dl/go1.17.darwin-arm64.tar.gz
==> [Info] Downloading to: /Users/pulkit.kathuria/.gobrew/downloads
Downloading   2% |████                                                                                                                                                                                                                        | (3.4/123 MB, 9.1 MB/s) [0s:13s]^Csignal: interrupt
╭─pulkit.kathuria@JP-GCJKVGQK0G^M ~/git/gobrew ‹feature/semantic-comply›
╰─$ go run cmd/gobrew/main.go ls-remote |tail -5                                                                                                                                                                                                                            1 ↵
	1.20rc1  1.20rc2  1.20rc3

1.21	1.21.0
	1.21rc1  1.21rc2  1.21rc3  1.21rc4
```