### PR TITLE
Add $HOME/go/bin to PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ go install github.com/kevincobain2000/gobrew/cmd/gobrew@latest
 Add `PATH` setting your shell config file (`.bashrc` or `.zshrc`).
 
  ```sh
-export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$PATH"
+export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$HOME/go/bin:$PATH"
 export GOROOT="$HOME/.gobrew/current/go"
 ```
 

--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -164,7 +164,7 @@ Installation Path:
 	} else {
 		msg = msg + `
     # Add gobrew to your ~/.bashrc or ~/.zshrc
-    export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$PATH"
+    export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$HOME/go/bin:$PATH"
     export GOROOT="$HOME/.gobrew/current/go"
 
 `


### PR DESCRIPTION
Some binaries are installed in `~/go/bin` when we run `go install pkg@version`. By default, this folder is not present in PATH. 
Providing instructions to add this folder to PATH. We can do the same for Windows too, would need to cross-check if the PATH is `%USERPROFILE%\go\bin` for windows.