### PR TITLE
remove redundant msg

### DIFF
--- a/gobrew.go
+++ b/gobrew.go
@@ -108,7 +108,6 @@ func (gb *GoBrew) Prune() {
 			version := f.Name()
 			color.Infoln("==> [Info] Uninstalling version:", version)
 			gb.Uninstall(version)
-			color.Infoln("==> [Info] Uninstalled version:", version)
 		}
 	}
 }


### PR DESCRIPTION
Before

```
╭─pulkit.kathuria@JP-GCJKVGQK0G^M ~/git
╰─$ gobrew prune
==> [Info] Current version: 1.21.1
==> [Info] Uninstalling version: 1.17
==> [Success] Version: 1.17 uninstalled
==> [Info] Uninstalled version: 1.17 <--------------- getting rid of this extra msg
==> [Info] Uninstalling version: 1.18
==> [Success] Version: 1.18 uninstalled
==> [Info] Uninstalled version: 1.18
==> [Info] Uninstalling version: 1.18.10
==> [Success] Version: 1.18.10 uninstalled
```

After

```
╰─$ go run cmd/gobrew/main.go prune
==> [Info] Current version: 1.21.1
==> [Info] Uninstalling version: 1.17
==> [Success] Version: 1.17 uninstalled
==> [Info] Uninstalling version: 1.18
==> [Success] Version: 1.18 uninstalled
```