### PR TITLE
judgeVersion panic when GITHUB_TOKEN env is set to an invalid token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ dist/
 bin/
 build/
 gobrew
+
+.vscode/

--- a/gobrew.go
+++ b/gobrew.go
@@ -365,6 +365,10 @@ func (gb *GoBrew) Install(version string) {
 		os.Exit(1)
 	}
 	version = gb.judgeVersion(version)
+	if version == "" {
+		color.Errorln("[Error] Can not judge version")
+		os.Exit(1)
+	}
 	gb.mkDirs(version)
 	if gb.existsVersion(version) {
 		color.Infof("==> [Info] Version: %s exists\n", version)
@@ -432,6 +436,10 @@ func (gb *GoBrew) judgeVersion(version string) string {
 					return judgedVersions[j]
 				}
 			}
+		}
+
+		if len(versionsSemantic) == 0 {
+			return ""
 		}
 
 		latest := versionsSemantic[len(versionsSemantic)-1].String()

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -100,6 +100,7 @@ func TestJudgeVersion(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.version, func(t *testing.T) {
+			os.Unsetenv("GITHUB_TOKEN")
 			gb := NewGoBrew()
 			version := gb.judgeVersion(test.version)
 			assert.Equal(t, test.wantVersion, version)

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -98,9 +98,9 @@ func TestJudgeVersion(t *testing.T) {
 		// 	wantVersion: "1.19.1",
 		// },
 	}
+	os.Unsetenv("GITHUB_TOKEN")
 	for _, test := range tests {
 		t.Run(test.version, func(t *testing.T) {
-			os.Unsetenv("GITHUB_TOKEN")
 			gb := NewGoBrew()
 			version := gb.judgeVersion(test.version)
 			assert.Equal(t, test.wantVersion, version)


### PR DESCRIPTION
I had an invalid GITHUB_TOKEN set on my account and this caused gobrew.ListRemoteVersions to return an empty list of versions.

Because the list is empty the code on gobrew.judgeVersion generates an panic as can be seen on the image bellow.

![image](https://github.com/kevincobain2000/gobrew/assets/66092/87014d6b-3467-416b-a4bf-c91bfcc07f84)

This PR contains a fix for the panic error.

Probably it is the same error reported on #135.