### PR TITLE
unable to obtain mod version

### DIFF
--- a/gobrew.go
+++ b/gobrew.go
@@ -501,7 +501,7 @@ func (gb *GoBrew) judgeVersion(version string) string {
 
 	if version == "mod" {
 		// get version by reading the mod file of Go
-		judgedVersion = gb.getModVersion()
+		return gb.getModVersion()
 	}
 	if version == "latest" || version == "dev-latest" {
 		groupedVersions := gb.ListRemoteVersions(false) // donot print


### PR DESCRIPTION
```
╰─$ go run cmd/gobrew/main.go use mod                                                                                                                                                                      
==> [Info] Fetching remote versions

==> [Info] Downloading version: mod
==> [Info] Downloading from: https://go.dev/dl/gomod.darwin-arm64.tar.gz
==> [Info] Downloading to: /Users/pulkit.kathuria/.gobrew/downloads
==> [Info] Downloading version failed: https://go.dev/dl/gomod.darwin-arm64.tar.gz returned status code 404
==> [Error]: Please check connectivity to url: https://go.dev/dl/gomod.darwin-arm64.tar.gz
                                                                   ↑ Fixes
```