### PR TITLE
feat: exclude Merge pull request from changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,3 +39,4 @@ changelog:
       - '^docs:'
       - '^test:'
       - '^bin'
+      - '^Merge pull'


### PR DESCRIPTION
Just for example:
https://github.com/juev/starred/releases

These changes allow you to exclude commits with Merge request from the changelog. In my opinion, the story is more readable and understandable.