### PR TITLE
Tests 06122023

### DIFF
--- a/gobrew.go
+++ b/gobrew.go
@@ -798,10 +798,7 @@ func (gb *GoBrew) getGolangVersions() (result []string) {
 func doRequest(url string) (data []byte) {
 	client := &http.Client{}
 	request, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		color.Errorln("==> [Error] Cannot create request:", err.Error())
-		return
-	}
+	utils.CheckError(err, "==> [Error] Cannot create request")
 
 	request.Header.Set("User-Agent", "gobrew")
 

--- a/gobrew.go
+++ b/gobrew.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -431,9 +432,14 @@ func (gb *GoBrew) CurrentVersion() string {
 		return ""
 	}
 
-	version := strings.ReplaceAll(fp, strings.Join([]string{"go", "bin"}, string(os.PathSeparator)), "")
-	version = strings.ReplaceAll(version, gb.versionsDir, "")
-	version = strings.ReplaceAll(version, string(os.PathSeparator), "")
+	version := strings.TrimSuffix(fp, strings.Join([]string{"go", "bin"}, string(os.PathSeparator)))
+	paths := strings.Split(version, string(os.PathSeparator))
+	slices.Reverse(paths)
+	for _, version = range paths {
+		if version != "" {
+			break
+		}
+	}
 	return version
 }
 

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestNewGobrewHomeDirUsesUserHomeDir(t *testing.T) {
-	t.Parallel()
 	homeDir, err := os.UserHomeDir()
 
 	if err != nil {
@@ -24,7 +23,6 @@ func TestNewGobrewHomeDirUsesUserHomeDir(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
-	t.Parallel()
 	var envName string
 
 	switch runtime.GOOS {
@@ -49,7 +47,6 @@ func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
-	t.Parallel()
 	oldEnvValue := os.Getenv("GOBREW_ROOT")
 	defer func() {
 		_ = os.Setenv("GOBREW_ROOT", oldEnvValue)
@@ -63,7 +60,6 @@ func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
 }
 
 func TestJudgeVersion(t *testing.T) {
-	//t.Parallel()
 	tests := []struct {
 		version     string
 		wantVersion string
@@ -107,7 +103,6 @@ func TestJudgeVersion(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.version, func(t *testing.T) {
-			//t.Parallel()
 			gb := NewGoBrew()
 			version := gb.judgeVersion(test.version)
 			assert.Equal(t, test.wantVersion, version)
@@ -117,7 +112,6 @@ func TestJudgeVersion(t *testing.T) {
 }
 
 func TestListVersions(t *testing.T) {
-	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 
@@ -125,7 +119,6 @@ func TestListVersions(t *testing.T) {
 }
 
 func TestExistVersion(t *testing.T) {
-	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 
@@ -135,7 +128,6 @@ func TestExistVersion(t *testing.T) {
 }
 
 func TestInstallAndExistVersion(t *testing.T) {
-	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	gb.Install("1.19")
@@ -144,7 +136,6 @@ func TestInstallAndExistVersion(t *testing.T) {
 }
 
 func TestUnInstallThenNotExistVersion(t *testing.T) {
-	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	gb.Uninstall("1.19")
@@ -153,7 +144,6 @@ func TestUnInstallThenNotExistVersion(t *testing.T) {
 }
 
 func TestUpgrade(t *testing.T) {
-	t.Parallel()
 	tempDir := t.TempDir()
 
 	gb := NewGoBrewDirectory(tempDir)
@@ -180,7 +170,6 @@ func TestUpgrade(t *testing.T) {
 }
 
 func TestDoNotUpgradeLatestVersion(t *testing.T) {
-	//t.Parallel()
 	t.Skip("skipping test...needs to rewrite")
 	tempDir := t.TempDir()
 
@@ -209,7 +198,6 @@ func TestDoNotUpgradeLatestVersion(t *testing.T) {
 }
 
 func TestInteractive(t *testing.T) {
-	t.Parallel()
 	tempDir := t.TempDir()
 
 	gb := NewGoBrewDirectory(tempDir)
@@ -241,7 +229,6 @@ func TestInteractive(t *testing.T) {
 }
 
 func TestPrune(t *testing.T) {
-	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	gb.Install("1.20")
@@ -253,7 +240,6 @@ func TestPrune(t *testing.T) {
 }
 
 func TestGoBrew_CurrentVersion(t *testing.T) {
-	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	assert.Equal(t, true, gb.CurrentVersion() == "")

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestNewGobrewHomeDirUsesUserHomeDir(t *testing.T) {
+	t.Parallel()
 	homeDir, err := os.UserHomeDir()
 
 	if err != nil {
@@ -23,13 +24,15 @@ func TestNewGobrewHomeDirUsesUserHomeDir(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
+	t.Parallel()
 	var envName string
 
-	if runtime.GOOS == "windows" {
+	switch runtime.GOOS {
+	case "windows":
 		envName = "USERPROFILE"
-	} else if runtime.GOOS == "plan9" {
+	case "plan9":
 		envName = "home"
-	} else {
+	default:
 		envName = "HOME"
 	}
 
@@ -46,6 +49,7 @@ func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
+	t.Parallel()
 	oldEnvValue := os.Getenv("GOBREW_ROOT")
 	defer func() {
 		_ = os.Setenv("GOBREW_ROOT", oldEnvValue)
@@ -59,6 +63,7 @@ func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
 }
 
 func TestJudgeVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		version     string
 		wantVersion string
@@ -88,8 +93,8 @@ func TestJudgeVersion(t *testing.T) {
 			version:     "1.18@dev-latest",
 			wantVersion: "1.18.10",
 		},
-		// // following 2 tests fail upon new version release
-		// // commenting out for now as the tool is stable
+		// following 2 tests fail upon new version release
+		// commenting out for now as the tool is stable
 		// {
 		// 	version:     "latest",
 		// 	wantVersion: "1.19.1",
@@ -100,7 +105,9 @@ func TestJudgeVersion(t *testing.T) {
 		// },
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
 			gb := NewGoBrew()
 			version := gb.judgeVersion(test.version)
 			assert.Equal(t, test.wantVersion, version)
@@ -110,6 +117,7 @@ func TestJudgeVersion(t *testing.T) {
 }
 
 func TestListVersions(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 
@@ -117,6 +125,7 @@ func TestListVersions(t *testing.T) {
 }
 
 func TestExistVersion(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 
@@ -126,13 +135,8 @@ func TestExistVersion(t *testing.T) {
 }
 
 func TestInstallAndExistVersion(t *testing.T) {
-	tempDir := filepath.Join(os.TempDir(), "gobrew-test-install-uninstall")
-	err := os.MkdirAll(tempDir, os.ModePerm)
-	if err != nil {
-		t.Skip("could not create directory for gobrew update:", err)
-		return
-	}
-
+	t.Parallel()
+	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	gb.Install("1.19")
 	exists := gb.existsVersion("1.19")
@@ -140,16 +144,8 @@ func TestInstallAndExistVersion(t *testing.T) {
 }
 
 func TestUnInstallThenNotExistVersion(t *testing.T) {
-	tempDir := filepath.Join(os.TempDir(), "gobrew-test-install-uninstall")
-	err := os.MkdirAll(tempDir, os.ModePerm)
-	if err != nil {
-		t.Skip("could not create directory for gobrew update:", err)
-		return
-	}
-	defer func() {
-		_ = os.RemoveAll(tempDir)
-	}()
-
+	t.Parallel()
+	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	gb.Uninstall("1.19")
 	exists := gb.existsVersion("1.19")
@@ -157,6 +153,7 @@ func TestUnInstallThenNotExistVersion(t *testing.T) {
 }
 
 func TestUpgrade(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	gb := NewGoBrewDirectory(tempDir)
@@ -183,6 +180,7 @@ func TestUpgrade(t *testing.T) {
 }
 
 func TestDoNotUpgradeLatestVersion(t *testing.T) {
+	t.Parallel()
 	t.Skip("skipping test...needs to rewrite")
 	tempDir := t.TempDir()
 
@@ -211,16 +209,8 @@ func TestDoNotUpgradeLatestVersion(t *testing.T) {
 }
 
 func TestInteractive(t *testing.T) {
-	tempDir := filepath.Join(os.TempDir(), "gobrew-test-interactive")
-	err := os.MkdirAll(tempDir, os.ModePerm)
-	if err != nil {
-		t.Skip("could not create directory for gobrew update:", err)
-		return
-	}
-
-	defer func() {
-		_ = os.RemoveAll(tempDir)
-	}()
+	t.Parallel()
+	tempDir := t.TempDir()
 
 	gb := NewGoBrewDirectory(tempDir)
 	currentVersion := gb.CurrentVersion()

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -63,7 +63,7 @@ func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
 }
 
 func TestJudgeVersion(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	tests := []struct {
 		version     string
 		wantVersion string
@@ -107,7 +107,7 @@ func TestJudgeVersion(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.version, func(t *testing.T) {
-			t.Parallel()
+			//t.Parallel()
 			gb := NewGoBrew()
 			version := gb.judgeVersion(test.version)
 			assert.Equal(t, test.wantVersion, version)
@@ -180,7 +180,7 @@ func TestUpgrade(t *testing.T) {
 }
 
 func TestDoNotUpgradeLatestVersion(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	t.Skip("skipping test...needs to rewrite")
 	tempDir := t.TempDir()
 
@@ -238,4 +238,26 @@ func TestInteractive(t *testing.T) {
 	currentVersion = gb.CurrentVersion()
 	currentVersion = strings.Replace(currentVersion, "private", "", -1)
 	assert.Equal(t, currentVersion, latestVersion)
+}
+
+func TestPrune(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	gb := NewGoBrewDirectory(tempDir)
+	gb.Install("1.20")
+	gb.Install("1.19")
+	gb.Use("1.19")
+	gb.Prune()
+	assert.Equal(t, false, gb.existsVersion("1.20"))
+	assert.Equal(t, true, gb.existsVersion("1.19"))
+}
+
+func TestGoBrew_CurrentVersion(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	gb := NewGoBrewDirectory(tempDir)
+	assert.Equal(t, true, gb.CurrentVersion() == "")
+	gb.Install("1.19")
+	gb.Use("1.19")
+	assert.Equal(t, true, gb.CurrentVersion() == "1.19")
 }


### PR DESCRIPTION
On my MacBook, taking a symlink from the current version returns the directory in the private directory.  As a result, the tests did not work.  Corrected the function to take the current version of gobrew.

Added tests for the function of taking the current version.

The temporary directory is generated directly in the test library.  You need to use it so that the directory is automatically deleted upon completion of the current test.