### PR TITLE
Refactoring 08122023

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
         run: go version
         shell: bash
       - name: Build
-        run: go build cmd/gobrew/main.go
+        run: go build cmd/gobrew
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,5 @@ jobs:
         run: go version
         shell: bash
       - name: Build
-        run: go build cmd/gobrew
+        run: go build ./cmd/gobrew
         shell: bash

--- a/.github/workflows/coveritup.yml
+++ b/.github/workflows/coveritup.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build
         run: |
           BUILD_START=$SECONDS
-          go build -ldflags '-s -w' -o main cmd/gobrew
+          go build -ldflags '-s -w' -o main ./cmd/gobrew
           echo SCORE=$(($SECONDS-BUILD_START)) >> "$GITHUB_ENV"
         shell: bash
 

--- a/.github/workflows/coveritup.yml
+++ b/.github/workflows/coveritup.yml
@@ -11,6 +11,7 @@ on:
       - '**/*.mod'
       - '**/*.sum'
       - '**/*.yaml'
+  workflow_dispatch:
 
 name: "Cover It Up"
 jobs:

--- a/.github/workflows/coveritup.yml
+++ b/.github/workflows/coveritup.yml
@@ -11,7 +11,6 @@ on:
       - '**/*.mod'
       - '**/*.sum'
       - '**/*.yaml'
-  workflow_dispatch:
 
 name: "Cover It Up"
 jobs:

--- a/.github/workflows/coveritup.yml
+++ b/.github/workflows/coveritup.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build
         run: |
           BUILD_START=$SECONDS
-          go build -ldflags '-s -w' -o main cmd/gobrew/main.go
+          go build -ldflags '-s -w' -o main cmd/gobrew
           echo SCORE=$(($SECONDS-BUILD_START)) >> "$GITHUB_ENV"
         shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           version: ${{ matrix.go-version }}
       - name: Test
-        run: go test -race -v ./... -count=1
+        run: go test -v ./...

--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"log"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -167,23 +166,7 @@ Examples:
     gobrew use dev-latest          # use go version latest avalable, including rc and beta
 
 Installation Path:
-`
-
-	if runtime.GOOS == "windows" {
-		msg = msg + `
-    # Add gobrew to your environment variables
-    PATH="%USERPROFILE%\.gobrew\current\bin;%USERPROFILE%\.gobrew\bin;%PATH%"
-    GOROOT="%USERPROFILE%\.gobrew\current\go"
-
-`
-	} else {
-		msg = msg + `
-    # Add gobrew to your ~/.bashrc or ~/.zshrc
-    export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$PATH"
-    export GOROOT="$HOME/.gobrew/current/go"
-
-`
-	}
+` + usageMsg
 
 	return msg
 }

--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -88,11 +88,10 @@ func main() {
 		gb.ListRemoteVersions(true)
 	case "install":
 		gb.Install(versionArg)
-		if gb.CurrentVersion() == "" {
+		if gb.CurrentVersion() == "None" {
 			gb.Use(versionArg)
 		}
 	case "use":
-		gb.Install(versionArg)
 		gb.Use(versionArg)
 	case "uninstall":
 		gb.Uninstall(versionArg)

--- a/cmd/gobrew/main_unix.go
+++ b/cmd/gobrew/main_unix.go
@@ -1,0 +1,10 @@
+//go:build unix
+
+package main
+
+const usageMsg = `
+    # Add gobrew to your ~/.bashrc or ~/.zshrc
+    export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$PATH"
+    export GOROOT="$HOME/.gobrew/current/go"
+
+`

--- a/cmd/gobrew/main_windows.go
+++ b/cmd/gobrew/main_windows.go
@@ -1,0 +1,8 @@
+package main
+
+const usageMsg = `
+    # Add gobrew to your ~/.bashrc or ~/.zshrc
+    export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$PATH"
+    export GOROOT="$HOME/.gobrew/current/go"
+
+`

--- a/gobrew.go
+++ b/gobrew.go
@@ -55,8 +55,6 @@ type GoBrew struct {
 	downloadsDir  string
 }
 
-var gb GoBrew
-
 // NewGoBrew instance
 func NewGoBrew() GoBrew {
 	homeDir, err := os.UserHomeDir()
@@ -72,6 +70,7 @@ func NewGoBrew() GoBrew {
 }
 
 func NewGoBrewDirectory(homeDir string) GoBrew {
+	gb := GoBrew{}
 	gb.homeDir = homeDir
 
 	gb.installDir = filepath.Join(gb.homeDir, goBrewDir)
@@ -281,9 +280,7 @@ func (gb *GoBrew) ListRemoteVersions(print bool) map[string][]string {
 	tags := gb.getGolangVersions()
 
 	var versions []string
-	for _, tag := range tags {
-		versions = append(versions, tag)
-	}
+	versions = append(versions, tags...)
 
 	return gb.getGroupedVersion(versions, print)
 }

--- a/gobrew.go
+++ b/gobrew.go
@@ -171,7 +171,7 @@ func (gb *GoBrew) getLatestVersion() string {
 		r := regexp.MustCompile("beta.*|rc.*")
 		matches := r.FindAllString(getGolangVersions[i], -1)
 		if len(matches) == 0 {
-			return strings.ReplaceAll(getGolangVersions[i], "go", "")
+			return getGolangVersions[i]
 		}
 	}
 	return ""
@@ -282,7 +282,7 @@ func (gb *GoBrew) ListRemoteVersions(print bool) map[string][]string {
 
 	var versions []string
 	for _, tag := range tags {
-		versions = append(versions, strings.ReplaceAll(tag, "go", ""))
+		versions = append(versions, tag)
 	}
 
 	return gb.getGroupedVersion(versions, print)
@@ -765,7 +765,7 @@ func (gb *GoBrew) getGolangVersions() (result []string) {
 	for _, tag := range tags {
 		t := strings.ReplaceAll(tag.Ref, "refs/tags/", "")
 		if strings.HasPrefix(t, "go") {
-			result = append(result, t)
+			result = append(result, strings.TrimPrefix(t, "go"))
 		}
 	}
 

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -25,7 +25,6 @@ func TestNewGobrewHomeDirUsesUserHomeDir(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
-	t.Parallel()
 	var envName string
 
 	switch runtime.GOOS {
@@ -51,7 +50,6 @@ func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
-	t.Parallel()
 	oldEnvValue := os.Getenv("GOBREW_ROOT")
 	defer func() {
 		_ = os.Setenv("GOBREW_ROOT", oldEnvValue)

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -208,7 +208,7 @@ func TestInteractive(t *testing.T) {
 	currentVersion := gb.CurrentVersion()
 	latestVersion := gb.getLatestVersion()
 	// modVersion := gb.getModVersion()
-	assert.Equal(t, "", currentVersion)
+	assert.Equal(t, "None", currentVersion)
 	assert.NotEqual(t, currentVersion, latestVersion)
 
 	ask := false
@@ -248,7 +248,7 @@ func TestPrune(t *testing.T) {
 func TestGoBrew_CurrentVersion(t *testing.T) {
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
-	assert.Equal(t, true, gb.CurrentVersion() == "")
+	assert.Equal(t, true, gb.CurrentVersion() == "None")
 	gb.Install("1.19")
 	gb.Use("1.19")
 	assert.Equal(t, true, gb.CurrentVersion() == "1.19")

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -173,7 +173,7 @@ func TestUpgrade(t *testing.T) {
 	binaryFile := filepath.Join(binaryDir, baseName)
 
 	if oldFile, err := os.Create(binaryFile); err == nil {
-		// on tests we have to close the file to avoid an error on os.Rename
+		// on tests, we have to close the file to avoid an error on os.Rename
 		_ = oldFile.Close()
 	}
 

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -45,9 +45,7 @@ func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
 
 func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
 	t.Setenv("GOBREW_ROOT", "some_fancy_value")
-
 	gobrew := NewGoBrew()
-
 	assert.Equal(t, "some_fancy_value", gobrew.homeDir)
 	t.Log("test finished")
 }

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -36,13 +36,7 @@ func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
 		envName = "HOME"
 	}
 
-	oldEnvValue := os.Getenv(envName)
-	defer func() {
-		_ = os.Setenv(envName, oldEnvValue)
-	}()
-
-	_ = os.Unsetenv(envName)
-
+	t.Setenv(envName, "")
 	gobrew := NewGoBrew()
 
 	assert.Equal(t, os.Getenv("HOME"), gobrew.homeDir)
@@ -50,12 +44,7 @@ func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
-	oldEnvValue := os.Getenv("GOBREW_ROOT")
-	defer func() {
-		_ = os.Setenv("GOBREW_ROOT", oldEnvValue)
-	}()
-
-	_ = os.Setenv("GOBREW_ROOT", "some_fancy_value")
+	t.Setenv("GOBREW_ROOT", "some_fancy_value")
 
 	gobrew := NewGoBrew()
 

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -211,8 +211,7 @@ func TestInteractive(t *testing.T) {
 	assert.Equal(t, "None", currentVersion)
 	assert.NotEqual(t, currentVersion, latestVersion)
 
-	ask := false
-	gb.Interactive(ask)
+	gb.Interactive(false)
 
 	currentVersion = gb.CurrentVersion()
 	// remove string private from currentVersion (for macOS) due to /private/var symlink issue
@@ -226,7 +225,7 @@ func TestInteractive(t *testing.T) {
 	assert.Equal(t, "1.16.5", currentVersion)
 	assert.NotEqual(t, currentVersion, latestVersion)
 
-	gb.Interactive(ask)
+	gb.Interactive(false)
 	currentVersion = gb.CurrentVersion()
 	currentVersion = strings.Replace(currentVersion, "private", "", -1)
 	assert.Equal(t, currentVersion, latestVersion)

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestNewGobrewHomeDirUsesUserHomeDir(t *testing.T) {
+	t.Parallel()
 	homeDir, err := os.UserHomeDir()
 
 	if err != nil {
@@ -24,6 +25,7 @@ func TestNewGobrewHomeDirUsesUserHomeDir(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
+	t.Parallel()
 	var envName string
 
 	switch runtime.GOOS {
@@ -49,6 +51,7 @@ func TestNewGobrewHomeDirDefaultsToHome(t *testing.T) {
 }
 
 func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
+	t.Parallel()
 	oldEnvValue := os.Getenv("GOBREW_ROOT")
 	defer func() {
 		_ = os.Setenv("GOBREW_ROOT", oldEnvValue)
@@ -63,6 +66,7 @@ func TestNewGobrewHomeDirUsesGoBrewRoot(t *testing.T) {
 }
 
 func TestJudgeVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		version     string
 		wantVersion string
@@ -106,6 +110,7 @@ func TestJudgeVersion(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.version, func(t *testing.T) {
+			t.Parallel()
 			gb := NewGoBrew()
 			version := gb.judgeVersion(test.version)
 			assert.Equal(t, test.wantVersion, version)
@@ -116,6 +121,7 @@ func TestJudgeVersion(t *testing.T) {
 }
 
 func TestListVersions(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 
@@ -124,6 +130,7 @@ func TestListVersions(t *testing.T) {
 }
 
 func TestExistVersion(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 
@@ -134,6 +141,7 @@ func TestExistVersion(t *testing.T) {
 }
 
 func TestInstallAndExistVersion(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	gb.Install("1.19")
@@ -143,6 +151,7 @@ func TestInstallAndExistVersion(t *testing.T) {
 }
 
 func TestUnInstallThenNotExistVersion(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	gb.Uninstall("1.19")
@@ -152,6 +161,7 @@ func TestUnInstallThenNotExistVersion(t *testing.T) {
 }
 
 func TestUpgrade(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	gb := NewGoBrewDirectory(tempDir)
@@ -202,6 +212,7 @@ func TestDoNotUpgradeLatestVersion(t *testing.T) {
 }
 
 func TestInteractive(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	gb := NewGoBrewDirectory(tempDir)
@@ -233,6 +244,7 @@ func TestInteractive(t *testing.T) {
 }
 
 func TestPrune(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	gb.Install("1.20")
@@ -245,6 +257,7 @@ func TestPrune(t *testing.T) {
 }
 
 func TestGoBrew_CurrentVersion(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	gb := NewGoBrewDirectory(tempDir)
 	assert.Equal(t, true, gb.CurrentVersion() == "None")


### PR DESCRIPTION
@kevincobain2000 

Conducted a small refactoring in the code base:
- do not use a global variable.  Now parallel running of tests will not lead to data races
- disabled the race check in regular tests, since we do not explicitly use goroutines.  The speed of passing tests should increase.  Alternatively, you can also disable it in coverit
- return None by default instead of an empty string
- in the listing of versions we immediately return versions without the go prefix
- in the main package I also divided it by operating system
- something else small

And by the way, the question is, why did you call the latest version v1.10.0?  And not 1.9.10?  There were no significant changes there either.

And I was faced with the fact that when changing the settings of coveritup.yml, the project build did not start.  That is, by changing the assembly process, I could not launch it without making changes to the project itself.  Not very comfortable.