### PR TITLE
Fix: Win10 symlink require privilege

### DIFF
--- a/gobrew.go
+++ b/gobrew.go
@@ -6,10 +6,8 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -268,26 +266,10 @@ func (gb *GoBrew) ListRemoteVersions(print bool) map[string][]string {
 
 // CurrentVersion get current version from symb link
 func (gb *GoBrew) CurrentVersion() string {
-	// https://github.com/golang/go/issues/63703
-	var fp string
-	if runtime.GOOS == "windows" {
-		cmd := fmt.Sprintf(
-			"Get-Item -Path %s | Select-Object -ExpandProperty Target",
-			gb.currentBinDir,
-		)
-		output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
-		if err != nil {
-			return "None"
-		}
-		fp = strings.TrimSpace(string(output))
-	} else {
-		var err error
-		fp, err = filepath.EvalSymlinks(gb.currentBinDir)
-		if err != nil {
-			return "None"
-		}
+	fp, err := evalSymlinks(gb.currentBinDir)
+	if err != nil {
+		return "None"
 	}
-
 	version := strings.TrimSuffix(fp, filepath.Join("go", "bin"))
 	version = filepath.Base(version)
 	if version == "." {

--- a/gobrew_unix.go
+++ b/gobrew_unix.go
@@ -4,6 +4,7 @@ package gobrew
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/kevincobain2000/gobrew/utils"
 )
@@ -15,4 +16,16 @@ const (
 
 func removeFile(goBrewFile string) {
 	utils.CheckError(os.Remove(goBrewFile), "==> [Error] Cannot remove binary file")
+}
+
+func symlink(oldname string, newname string) {
+	utils.CheckError(os.Symlink(oldname, newname), "==> [Error]: symbolic link failed")
+}
+
+func evalSymlinks(path string) (string, error) {
+	fp, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	return fp, nil
 }

--- a/gobrew_windows.go
+++ b/gobrew_windows.go
@@ -1,7 +1,10 @@
 package gobrew
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/kevincobain2000/gobrew/utils"
 )
@@ -14,4 +17,24 @@ const (
 func removeFile(goBrewFile string) {
 	goBrewOldFile := goBrewFile + ".old"
 	utils.CheckError(os.Rename(goBrewFile, goBrewOldFile), "==> [Error] Cannot rename binary file")
+}
+
+func symlink(oldname string, newname string) {
+	utils.CheckError(
+		exec.Command("cmd", "/c", "mklink", "/J", newname, oldname).Run(),
+		"==> [Error]: symbolic link failed",
+	)
+}
+
+// https://github.com/golang/go/issues/63703
+func evalSymlinks(path string) (string, error) {
+	cmd := fmt.Sprintf(
+		"Get-Item -Path %s | Select-Object -ExpandProperty Target",
+		path,
+	)
+	output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), err
 }

--- a/helpers.go
+++ b/helpers.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -350,27 +349,13 @@ func (gb *GoBrew) downloadAndExtract(version string) {
 func (gb *GoBrew) changeSymblinkGoBin(version string) {
 	goBinDst := filepath.Join(gb.versionsDir, version, "/go/bin")
 	_ = os.RemoveAll(gb.currentBinDir)
-	if runtime.GOOS == "windows" {
-		utils.CheckError(
-			exec.Command("cmd", "/c", "mklink", "/J", gb.currentBinDir, goBinDst).Run(),
-			"==> [Error]: symbolic link failed",
-		)
-		return
-	}
-	utils.CheckError(os.Symlink(goBinDst, gb.currentBinDir), "==> [Error]: symbolic link failed")
+	symlink(goBinDst, gb.currentBinDir)
 }
 
 func (gb *GoBrew) changeSymblinkGo(version string) {
 	_ = os.RemoveAll(gb.currentGoDir)
 	versionGoDir := filepath.Join(gb.versionsDir, version, "go")
-	if runtime.GOOS == "windows" {
-		utils.CheckError(
-			exec.Command("cmd", "/c", "mklink", "/J", gb.currentGoDir, versionGoDir).Run(),
-			"==> [Error]: symbolic link failed",
-		)
-		return
-	}
-	utils.CheckError(os.Symlink(versionGoDir, gb.currentGoDir), "==> [Error]: symbolic link failed")
+	symlink(versionGoDir, gb.currentGoDir)
 }
 
 func (gb *GoBrew) getGobrewVersion() string {

--- a/helpers.go
+++ b/helpers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -349,12 +350,26 @@ func (gb *GoBrew) downloadAndExtract(version string) {
 func (gb *GoBrew) changeSymblinkGoBin(version string) {
 	goBinDst := filepath.Join(gb.versionsDir, version, "/go/bin")
 	_ = os.RemoveAll(gb.currentBinDir)
+	if runtime.GOOS == "windows" {
+		utils.CheckError(
+			exec.Command("cmd", "/c", "mklink", "/J", gb.currentBinDir, goBinDst).Run(),
+			"==> [Error]: symbolic link failed",
+		)
+		return
+	}
 	utils.CheckError(os.Symlink(goBinDst, gb.currentBinDir), "==> [Error]: symbolic link failed")
 }
 
 func (gb *GoBrew) changeSymblinkGo(version string) {
 	_ = os.RemoveAll(gb.currentGoDir)
 	versionGoDir := filepath.Join(gb.versionsDir, version, "go")
+	if runtime.GOOS == "windows" {
+		utils.CheckError(
+			exec.Command("cmd", "/c", "mklink", "/J", gb.currentGoDir, versionGoDir).Run(),
+			"==> [Error]: symbolic link failed",
+		)
+		return
+	}
 	utils.CheckError(os.Symlink(versionGoDir, gb.currentGoDir), "==> [Error]: symbolic link failed")
 }
 


### PR DESCRIPTION
## Problem
1. Symlink on Windows 10 Powershell required privilege, so we need to use `cmd` to create a symlink with `mklink`. See issue https://github.com/kevincobain2000/gobrew/issues/174

2. `filepath.EvalSymlinks` doesn't work correctly on Windows. A fix is currently being proposed: https://github.com/golang/go/issues/63703