### PR TITLE
installer script

### DIFF
--- a/git.io.sh
+++ b/git.io.sh
@@ -11,6 +11,7 @@ mkdir -p $GOBREW_BIN_DIR
 
 GOBREW_ARCH_BIN=''
 GOBREW_BIN='gobrew'
+GOBREW_VERSION=${1:-latest}
 
 THISOS=$(uname -s)
 ARCH=$(uname -m)
@@ -56,10 +57,15 @@ if [ -z "$GOBREW_ARCH_BIN" ]; then
    exit 1
 fi
 
-echo "Installing gobrew from: https://github.com/kevincobain2000/gobrew/releases/latest/download/$GOBREW_ARCH_BIN ..."
+DOWNLOAD_URL="https://github.com/kevincobain2000/gobrew/releases/download/$GOBREW_VERSION/$GOBREW_ARCH_BIN"
+if [ "$GOBREW_VERSION" = "latest" ]; then
+  DOWNLOAD_URL="https://github.com/kevincobain2000/gobrew/releases/$GOBREW_VERSION/download/$GOBREW_ARCH_BIN"
+fi
+
+echo "Installing gobrew from: $DOWNLOAD_URL"
 echo ""
 
-curl -kL --progress-bar https://github.com/kevincobain2000/gobrew/releases/latest/download/$GOBREW_ARCH_BIN -o $GOBREW_BIN_DIR/$GOBREW_BIN
+curl -kL --progress-bar $DOWNLOAD_URL -o $GOBREW_BIN_DIR/$GOBREW_BIN
 
 chmod +x $GOBREW_BIN_DIR/$GOBREW_BIN
 


### PR DESCRIPTION
Fixes #176 

```
╰─$ cat git.io.sh| sh -s -- v1.10.4
Installing gobrew from: https://github.com/kevincobain2000/gobrew/releases/download/v1.10.4/gobrew-darwin-arm64

######################################################################## 100.0%
Installed successfully to: /Users/pulkit.kathuria/.gobrew/bin/gobrew
============================

╰─$ gobrew version
[INFO] gobrew version is 1.10.4
```

Normally

```
╰─$ cat git.io.sh| sh
Installing gobrew from: https://github.com/kevincobain2000/gobrew/releases/latest/download/gobrew-darwin-arm64

######################################################################## 100.0%

╰─$ gobrew version
[INFO] gobrew version is 1.10.6
```