### PR TITLE
pick the latest in order for `dev-latest`

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -224,8 +224,16 @@ func (gb *GoBrew) judgeVersion(version string) string {
 				if len(judgedVersions) == 0 {
 					return "None"
 				}
+				// Filter versions containing "rc" or "beta"
+				filteredVersions := gb.filterVersions(judgedVersions, []string{"rc", "beta"})
 
-				return judgedVersions[0]
+				// Get the last element of the filtered slice
+				var lastVersion string
+				if len(filteredVersions) > 0 {
+					lastVersion = filteredVersions[len(filteredVersions)-1]
+				}
+
+				return lastVersion
 			}
 
 			// loop in reverse
@@ -312,6 +320,20 @@ func (gb *GoBrew) mkDirs(version string) {
 
 func (gb *GoBrew) getVersionDir(version string) string {
 	return filepath.Join(gb.versionsDir, version)
+}
+
+// filterVersions returns a new slice containing only the elements that contain any of the substrings in contains
+func (gb *GoBrew) filterVersions(versions []string, contains []string) []string {
+	var filtered []string
+	for _, version := range versions {
+		for _, contain := range contains {
+			if strings.Contains(version, contain) {
+				filtered = append(filtered, version)
+				break // Move to the next version after the first match
+			}
+		}
+	}
+	return filtered
 }
 
 func (gb *GoBrew) downloadAndExtract(version string) {

--- a/helpers.go
+++ b/helpers.go
@@ -199,6 +199,9 @@ func (gb *GoBrew) judgeVersion(version string) string {
 		return gb.judgeVersion(modVersion)
 	}
 	groupedVersions := gb.ListRemoteVersions(false) // donot print
+
+	// latest will pick the latest version excluding rc and beta
+	// dev-latest will first remove rc and beta from the list of versions and then pick the latest version
 	if version == "latest" || version == "dev-latest" {
 		groupedVersionKeys := make([]string, 0, len(groupedVersions))
 		for groupedVersionKey := range groupedVersions {

--- a/helpers.go
+++ b/helpers.go
@@ -224,7 +224,8 @@ func (gb *GoBrew) judgeVersion(version string) string {
 				if len(judgedVersions) == 0 {
 					return "None"
 				}
-				return judgedVersions[len(judgedVersions)-1]
+
+				return judgedVersions[0]
 			}
 
 			// loop in reverse


### PR DESCRIPTION
Fixes #179 

Semantic ordering is

```
[]string{
  "1.22rc1",
  "1.22rc2",
  "1.22.0",
}
```

I wonder if it ever worked actually. It had been there since the beginning.