### PR TITLE
Add golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,27 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      -
+        uses: actions/checkout@v4
+      -
+        uses: kevincobain2000/action-gobrew@v2
+        with:
+          version: latest
+      -
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - bodyclose
     - dupl
     - errorlint
     - exportloopref
@@ -20,7 +19,6 @@ linters:
     - goprintffuncname
     - gosec
     - prealloc
-    - predeclared
     - revive
     - stylecheck
     - whitespace

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,26 @@
+linters:
+  # Disable all linters.
+  # Default: false
+  disable-all: true
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - bodyclose
+    - dupl
+    - errorlint
+    - exportloopref
+    - goconst
+    - gocritic
+    - gocyclo
+    - goprintffuncname
+    - gosec
+    - prealloc
+    - predeclared
+    - revive
+    - stylecheck
+    - whitespace

--- a/cmd/gobrew/main.go
+++ b/cmd/gobrew/main.go
@@ -67,7 +67,7 @@ func init() {
 			// Check if the major version is 1 and the minor version is 21 or greater
 			if majorVersionNum == 1 && minorVersionNum >= 21 {
 				// Modify the versionArg to include ".0"
-				versionArg = versionArg + ".0"
+				versionArg += ".0"
 			}
 		}
 	}
@@ -88,10 +88,10 @@ func main() {
 
 	config := gobrew.Config{
 		RootDir:           rootDir,
-		RegistryPathUrl:   registryPath,
-		GobrewDownloadUrl: gobrew.DownloadUrl,
-		GobrewTags:        gobrew.TagsApi,
-		GobrewVersionsUrl: gobrew.VersionsUrl,
+		RegistryPathURL:   registryPath,
+		GobrewDownloadURL: gobrew.DownloadURL,
+		GobrewTags:        gobrew.TagsAPI,
+		GobrewVersionsURL: gobrew.VersionsURL,
 	}
 
 	gb := gobrew.NewGoBrew(config)
@@ -108,7 +108,7 @@ func main() {
 		gb.ListRemoteVersions(true)
 	case "install":
 		gb.Install(versionArg)
-		if gb.CurrentVersion() == "None" {
+		if gb.CurrentVersion() == gobrew.NoneVersion {
 			gb.Use(versionArg)
 		}
 	case "use":

--- a/cmd/gobrew/main_windows.go
+++ b/cmd/gobrew/main_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package main
 
 const usageMsg = `

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kevincobain2000/gobrew
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/gobrew_test.go
+++ b/gobrew_test.go
@@ -13,13 +13,13 @@ import (
 
 func setupGobrew(t *testing.T, ts *httptest.Server) GoBrew {
 	tags, _ := url.JoinPath(ts.URL, "golang-tags.json")
-	versionUrl, _ := url.JoinPath(ts.URL, "latest")
+	versionURL, _ := url.JoinPath(ts.URL, "latest")
 	config := Config{
 		RootDir:           t.TempDir(),
-		RegistryPathUrl:   ts.URL,
-		GobrewDownloadUrl: ts.URL,
+		RegistryPathURL:   ts.URL,
+		GobrewDownloadURL: ts.URL,
 		GobrewTags:        tags,
-		GobrewVersionsUrl: versionUrl,
+		GobrewVersionsURL: versionURL,
 	}
 	gb := NewGoBrew(config)
 	return gb
@@ -59,7 +59,7 @@ func TestUpgrade(t *testing.T) {
 	binaryDir := filepath.Join(gb.installDir, "bin")
 	_ = os.MkdirAll(binaryDir, os.ModePerm)
 
-	baseName := "gobrew" + fileExt
+	baseName := ProgramName + fileExt
 	binaryFile := filepath.Join(binaryDir, baseName)
 
 	if oldFile, err := os.Create(binaryFile); err == nil {
@@ -84,7 +84,7 @@ func TestDoNotUpgradeLatestVersion(t *testing.T) {
 	binaryDir := filepath.Join(gb.installDir, "bin")
 	_ = os.MkdirAll(binaryDir, os.ModePerm)
 
-	baseName := "gobrew" + fileExt
+	baseName := ProgramName + fileExt
 	binaryFile := filepath.Join(binaryDir, baseName)
 
 	currentVersion := gb.getGobrewVersion()
@@ -109,7 +109,7 @@ func TestInteractive(t *testing.T) {
 
 	currentVersion := gb.CurrentVersion()
 	latestVersion := gb.getLatestVersion()
-	assert.Equal(t, "None", currentVersion)
+	assert.Equal(t, NoneVersion, currentVersion)
 	assert.NotEqual(t, currentVersion, latestVersion)
 
 	gb.Interactive(false)
@@ -148,7 +148,7 @@ func TestGoBrew_CurrentVersion(t *testing.T) {
 	ts := httptest.NewServer(http.FileServer(http.Dir("testdata")))
 	defer ts.Close()
 	gb := setupGobrew(t, ts)
-	assert.Equal(t, true, gb.CurrentVersion() == "None")
+	assert.Equal(t, true, gb.CurrentVersion() == NoneVersion)
 	gb.Install("1.19")
 	gb.Use("1.19")
 	assert.Equal(t, true, gb.CurrentVersion() == "1.19")

--- a/helpers.go
+++ b/helpers.go
@@ -284,7 +284,6 @@ func (gb *GoBrew) hasModFile() bool {
 	return false
 }
 
-// nolint:gocritic
 // read go.mod file and extract version
 // Do not use go to get the version as go list -m -f '{{.GoVersion}}'
 // Because go might not be installed
@@ -308,7 +307,7 @@ func (gb *GoBrew) getModVersion() string {
 
 	if err = scanner.Err(); err != nil {
 		color.Errorln(err)
-		os.Exit(1)
+		os.Exit(1) // nolint:gocritic
 	}
 	return NoneVersion
 }
@@ -421,7 +420,6 @@ func (gb *GoBrew) getGolangVersions() (result []string) {
 	return
 }
 
-// nolint:gocritic
 func doRequest(url string) (data []byte) {
 	client := &http.Client{}
 	request, err := http.NewRequest("GET", url, nil)
@@ -439,12 +437,12 @@ func doRequest(url string) (data []byte) {
 	if response.StatusCode == http.StatusTooManyRequests ||
 		response.StatusCode == http.StatusForbidden {
 		color.Errorln("==> [Error] Rate limit exhausted")
-		os.Exit(1)
+		os.Exit(1) // nolint:gocritic
 	}
 
 	if response.StatusCode != http.StatusOK {
 		color.Errorln("==> [Error] Cannot read response:", response.Status)
-		os.Exit(1)
+		os.Exit(1) // nolint:gocritic
 	}
 
 	data, err = io.ReadAll(response.Body)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -62,7 +62,6 @@ func TestJudgeVersion(t *testing.T) {
 			gb := setupGobrew(t, ts)
 			version := gb.judgeVersion(test.version)
 			assert.Equal(t, test.wantVersion, version)
-
 		})
 	}
 	t.Log("test finished")


### PR DESCRIPTION
Using golangci-link makes it easier to check the code and avoid a lot of problems.

This is only a draft of changes so far.

First, after changing the golang version to 1.22 in the go.mod file, many utilities stopped working. According to issue, we corrected the version, specifying it more precisely. After that, everything worked as it should.

Performed adding a new pipe and configuration for golangci-lint to standardize checks.

At the current moment, we have a number of problems that I plan to fix in the current PR.

Please do not merge this changes until they are ready to go.