### PR TITLE
fix: help message for windows

### DIFF
--- a/cmd/gobrew/main_windows.go
+++ b/cmd/gobrew/main_windows.go
@@ -3,8 +3,8 @@
 package main
 
 const usageMsg = `
-    # Add gobrew to your ~/.bashrc or ~/.zshrc
-    export PATH="$HOME/.gobrew/current/bin:$HOME/.gobrew/bin:$PATH"
-    export GOROOT="$HOME/.gobrew/current/go"
+    # Add gobrew to your environment variables
+    PATH="%USERPROFILE%\.gobrew\current\bin;%USERPROFILE%\.gobrew\bin;%PATH%"
+    GOROOT="%USERPROFILE%\.gobrew\current\go"
 
 `


### PR DESCRIPTION
After refactoring and allocating separate files to store messages for different systems, an error was made. Both the unix and windows files contained the same message.

This PR corrects this error.