### PR TITLE
Update .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,8 +16,6 @@ builds:
       - arm64
       - arm
     ignore:
-      - goos: windows
-        goarch: arm64
       - goos: freebsd
         goarch: arm64
       - goos: windows


### PR DESCRIPTION
removed the ignore for windows arm64, so we can see if this works on my windows arm64 machine.

part of https://github.com/kevincobain2000/gobrew/issues/187